### PR TITLE
Support azjezz/psl 2.x (keep supporting 1.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.0",
         "ext-soap": "*",
         "ext-dom": "*",
-        "azjezz/psl": "^1.9",
+        "azjezz/psl": "^1.9 || ^2.1",
         "php-soap/engine": "^1.1",
         "php-soap/wsdl": "^1.0",
         "symfony/options-resolver": "^5.3 || ^6.0"

--- a/src/Wsdl/PermanentWsdlLoaderProvider.php
+++ b/src/Wsdl/PermanentWsdlLoaderProvider.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Soap\ExtSoapEngine\Wsdl;
 
+use Psl\File\WriteMode;
 use Soap\ExtSoapEngine\Wsdl\Naming\Md5Strategy;
 use Soap\ExtSoapEngine\Wsdl\Naming\NamingStrategy;
 use Soap\Wsdl\Loader\WsdlLoader;
+use function Psl\File\write;
 use function Psl\Filesystem\exists;
 use function Psl\Filesystem\write_file;
 
@@ -30,7 +32,12 @@ final class PermanentWsdlLoaderProvider implements WsdlProvider
             return $file;
         }
 
-        write_file($file, ($this->loader)($location));
+        $content = ($this->loader)($location);
+        if (! function_exists('Psl\\Filesystem\\write_file')) {
+            write($file, $content, WriteMode::TRUNCATE);
+        } else {
+            write_file($file, $content);
+        }
 
         return $file;
     }

--- a/src/Wsdl/TemporaryWsdlLoaderProvider.php
+++ b/src/Wsdl/TemporaryWsdlLoaderProvider.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Soap\ExtSoapEngine\Wsdl;
 
+use Psl\File\WriteMode;
 use Soap\ExtSoapEngine\Wsdl\Naming\Md5Strategy;
 use Soap\ExtSoapEngine\Wsdl\Naming\NamingStrategy;
 use Soap\Wsdl\Loader\WsdlLoader;
+use function Psl\File\write;
 use function Psl\Filesystem\write_file;
 
 final class TemporaryWsdlLoaderProvider implements WsdlProvider
@@ -23,7 +25,13 @@ final class TemporaryWsdlLoaderProvider implements WsdlProvider
         $namingStrategy = $this->namingStrategy ?? new Md5Strategy();
         $file = $cacheDir . DIRECTORY_SEPARATOR . $namingStrategy($location);
 
-        write_file($file, ($this->loader)($location));
+        $content = ($this->loader)($location);
+
+        if (! function_exists('Psl\\Filesystem\\write_file')) {
+            write($file, $content, WriteMode::TRUNCATE);
+        } else {
+            write_file($file, $content);
+        }
 
         return $file;
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Follow up to https://github.com/php-soap/ext-soap-engine/pull/10

#### Summary

Add support to PSL 2.x without dropping support for 1.x.

Please let me know if this would be an acceptable solution and I'll be happy to make it cleaner if you like :)