### PR TITLE
Parse special chars like - in method and type names

### DIFF
--- a/src/Metadata/MethodsParser.php
+++ b/src/Metadata/MethodsParser.php
@@ -68,14 +68,14 @@ final class MethodsParser
 
     private function parseName(string $methodString): string
     {
-        preg_match('/^\w+ (?P<name>\w+)/', $methodString, $matches);
+        preg_match('/^[\w-]+ (?P<name>[\w-]+)/', $methodString, $matches);
 
         return $matches['name'];
     }
 
     private function parseReturnType(string $methodString): XsdType
     {
-        preg_match('/^(?P<returnType>\w+)/', $methodString, $matches);
+        preg_match('/^(?P<returnType>[\w-]+)/', $methodString, $matches);
 
         return $this->xsdTypes->fetchByNameWithFallback($matches['returnType']);
     }

--- a/tests/Unit/Metadata/MethodsParserTest.php
+++ b/tests/Unit/Metadata/MethodsParserTest.php
@@ -33,14 +33,15 @@ final class MethodsParserTest extends TestCase
                 'TestResponse Test0Param()',
                 'TestResponse Test1Param(Test1 $parameter1)',
                 'TestResponse Test2Param(Test1 $parameter1, Test2 $parameter2)',
-                'list(Response1 $response1, Response2 $response2) TestReturnList()',
+                'list(Response1 $response1, Response-2 $response2, Response_3 $response3) TestReturnList()',
                 'list(Response1 $response1, Response2 $response2) TestReturnListWithParams(Test1 $parameter1, Test2 $parameter2)',
                 'simpleType TestSimpleType(simpleType $parameter1)',
+                'Test-Response Test-Method(Test-1 $parameter-1)',
+                'Test_Response Test_Method(Test_1 $parameter_1)',
             ]
         ]);
 
         $result = $this->parser->parse($client);
-
         static::assertCount(count($methods), $result);
         static::assertEquals(
             new Method(
@@ -99,6 +100,26 @@ final class MethodsParserTest extends TestCase
                 XsdType::create('simpleType')->withBaseType('string')
             ),
             $result->fetchByName('TestSimpleType')
+        );
+        static::assertEquals(
+            new Method(
+                'Test-Method',
+                new ParameterCollection(
+                    new Parameter('parameter-1', XsdType::create('Test-1'))
+                ),
+                XsdType::create('Test-Response')
+            ),
+            $result->fetchByName('Test-Method')
+        );
+        static::assertEquals(
+            new Method(
+                'Test_Method',
+                new ParameterCollection(
+                    new Parameter('parameter_1', XsdType::create('Test_1'))
+                ),
+                XsdType::create('Test_Response')
+            ),
+            $result->fetchByName('Test_Method')
         );
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/phpro/soap-client/discussions/499

#### Summary

Allows parsing type information like:

```
'Test-Response Test-Method(Test-1 $parameter-1)',
'Test_Response Test_Method(Test_1 $parameter_1)',
```
