### PR TITLE
Replace azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-soap": "*",
         "ext-dom": "*",
-        "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "php-soap/engine": "^2.16",
         "php-soap/wsdl": "^1.14",
         "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"


### PR DESCRIPTION
## Summary
- Replace `azjezz/psl` with `php-standard-library/php-standard-library` (drop-in replacement)
- Add `^6.0` to the version constraint

## Context
Ref: phpro/soap-client#604

## Test plan
- [x] `composer validate` passes
- [x] `composer update` resolves successfully