### PR TITLE
Bump PHP 8.4 minimum and update dependencies

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,20 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-soap": "*",
         "ext-dom": "*",
-        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "php-soap/engine": "^2.16",
-        "php-soap/wsdl": "^1.14",
+        "php-standard-library/file": "^6.1",
+        "php-standard-library/filesystem": "^6.1",
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/type": "^6.1",
+        "php-soap/engine": "^2.20",
+        "php-soap/wsdl": "^1.19",
         "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "php-soap/engine-integration-tests": "^1.10",
-        "php-soap/xml": "^1.9",
+        "php-soap/engine-integration-tests": "^1.12",
+        "php-soap/xml": "^1.10",
         "phpunit/phpunit": "~12.3",
         "vimeo/psalm": "~6.13",
         "php-cs-fixer/shim": "~3.88"

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     errorLevel="2"
     resolveFromConfigFile="true"
     strictBinaryOperands="true"
-    phpVersion="8.1"
+    phpVersion="8.4"
     allowStringToStandInForClass="true"
     rememberPropertyAssignmentsAfterCall="false"
     skipChecksOnUnresolvableIncludes="false"


### PR DESCRIPTION
## Summary

- Drop PHP 8.3 support, require PHP ~8.4.0 || ~8.5.0
- Replace monolithic `php-standard-library/php-standard-library` with standalone packages (`file`, `filesystem`, `foundation`, `type`) at ^6.1
- Bump `php-soap/engine` to ^2.20, `php-soap/wsdl` to ^1.19
- Bump `php-soap/engine-integration-tests` to ^1.12, `php-soap/xml` to ^1.10
- Update psalm `phpVersion` to 8.4

## Validation

- php-cs-fixer: 0 issues
- psalm: no errors
- phpunit: 226 tests pass (local PHP 8.4.13 and Docker PHP 8.4.19 with libxml 2.9.14)